### PR TITLE
Organize example script into dedicated directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Beacon = GiantsBeacon()
 Beacon.device_state("round")  # can be "round", "blink" or "off"
 ```
 
+For a complete example of switching between modes, see [examples/basic_usage.py](examples/basic_usage.py).
+
 The device_state can be "round", "blink" or "off".
 
 The Beacon will be turned off after 10 seconds automatically. If you want to let the beacon turn on permanently, 

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 # Ensure the package in ``src`` is importable when running directly from the
 # repository root.
-sys.path.append(str(Path(__file__).resolve().parent / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from giants_beacon import GiantsBeacon
 
@@ -14,3 +14,4 @@ sleep(5)  # wait 5 seconds
 beacon.device_state("blink")  # make the beacon blink
 sleep(5)  # wait 5 seconds
 beacon.device_state("off")  # turn the beacon off
+


### PR DESCRIPTION
## Summary
- Move example.py to examples/basic_usage.py and fix module import path
- Add reference to the new example in README

## Testing
- `python -m py_compile examples/basic_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_6899c94885cc8331ac1e8f43478b256c