### PR TITLE
Add pyproject configuration and CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "giants-software-usb-beacon"
+version = "0.1.0"
+description = "Control the Giants Software USB Beacon"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "hidapi>=0.12.0.post2",
+]
+
+[project.scripts]
+giants-beacon = "giants_beacon.__main__:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/giants_beacon/__main__.py
+++ b/src/giants_beacon/__main__.py
@@ -1,0 +1,22 @@
+import argparse
+
+def main() -> None:
+    """Command-line interface for controlling the USB Beacon."""
+    parser = argparse.ArgumentParser(
+        description="Control the Giants Software USB Beacon"
+    )
+    parser.add_argument(
+        "state",
+        choices=["round", "blink", "off"],
+        help="LED behavior to set",
+    )
+    args = parser.parse_args()
+
+    from . import GiantsBeacon
+
+    beacon = GiantsBeacon()
+    beacon.device_state(args.state)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define project metadata and dependencies in a new `pyproject.toml`
- configure setuptools build system with console script entry point
- implement basic CLI for controlling the USB Beacon

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=src python - <<'PY'
import sys, types
sys.modules['hid'] = types.SimpleNamespace(device=lambda: None, enumerate=lambda: [])
sys.argv = ['giants-beacon', '--help']
import giants_beacon.__main__ as gm
gm.main()
PY`
- `pip install hidapi==0.12.0.post2` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_6899ca10131883318dd9e1cde0b6e5c2